### PR TITLE
fixing monitorinigTabs check

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,4 +1,4 @@
-var monitoringTabs = []; 
+var monitoringTabs = {}; 
 var theDiv = null;
 var lastText = "";
 
@@ -21,10 +21,7 @@ var documentObserver = new MutationObserver(async function(mutations, observer) 
         return;
     }
 
-    monitoringTabs.push({
-        key: tabid,
-        value: true
-    });
+    monitoringTabs[tabid] = true;
 
     elements = document.querySelectorAll("[class*=code_panel__serial__text]");
     if (elements != null && elements.length > 0) {        


### PR DESCRIPTION
The original monitoringTabs duplicate check was failing, hence creating an infinite amount of listeners, eventually crashing the browser. 

This proposed fix simply replaces it with an object, which should allow the check to actually work. 

